### PR TITLE
improve

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -46,6 +46,15 @@
     #define DEFAULT_LCD_CONTRAST 17
   #endif
 
+  #if ENABLED(ANET_KEYPAD_LCD)
+    #define REPRAPWORLD_KEYPAD
+    #define REPRAPWORLD_KEYPAD_MOVE_STEP 10.0
+    #define ADC_KEYPAD
+    // this helps to implement ADC_KEYPAD menus
+    #define ENCODER_STEPS_PER_MENU_ITEM 1
+    #define REVERSE_MENU_DIRECTION
+  #endif
+
   #if ENABLED(miniVIKI) || ENABLED(VIKI2) || ENABLED(ELB_FULL_GRAPHIC_CONTROLLER)
     #define ULTRA_LCD  //general LCD support, also 16x2
     #define DOGLCD  // Support for SPI LCD 128x64 (Controller ST7565R graphic Display Family)
@@ -92,7 +101,7 @@
     #endif
   #endif
 
-  #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
+  #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) || ENABLED(ANET_FULL_GRAPHICS_LCD)
     #define DOGLCD
     #define U8GLIB_ST7920
     #define REPRAP_DISCOUNT_SMART_CONTROLLER

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1177,11 +1177,8 @@
  */
 //#define ULTRA_LCD   // Character based
 //#define DOGLCD      // Full graphics display
-
 #define ANET_KEYPAD_LCD
 //#define ANET_FULL_GRAPHICS_LCD
-// RepRap Discount (with Anet Adapter wiring see: http://www.thingiverse.com/thing:2103748)
-//#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
 
 /**
  * SD CARD

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -373,7 +373,7 @@
 // or to allow moving the extruder regardless of the hotend temperature.
 // *** IT IS HIGHLY RECOMMENDED TO LEAVE THIS OPTION ENABLED! ***
 #define PREVENT_COLD_EXTRUSION
-#define EXTRUDE_MINTEMP 170
+#define EXTRUDE_MINTEMP 160
 
 // This option prevents a single extrusion longer than EXTRUDE_MAXLENGTH.
 // Note that for Bowden Extruders a too-small value here may prevent loading.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -77,7 +77,7 @@
 #define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
 #define SHOW_BOOTSCREEN
 #define STRING_SPLASH_LINE1 SHORT_BUILD_VERSION // will be shown during bootup in line 1
-#define STRING_SPLASH_LINE2 WEBSITE_URL         // will be shown during bootup in line 2
+//#define STRING_SPLASH_LINE2 WEBSITE_URL         // will be shown during bootup in line 2
 
 //
 // *** VENDORS PLEASE READ *****************************************************
@@ -110,7 +110,7 @@
  *
  * :[2400, 9600, 19200, 38400, 57600, 115200, 250000]
  */
-#define BAUDRATE 250000
+#define BAUDRATE 115200
 
 // Enable the Bluetooth serial interface on AT90USB devices
 //#define BLUETOOTH
@@ -118,7 +118,7 @@
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_14_EFB
+  #define MOTHERBOARD BOARD_ANET_10
 #endif
 
 // Optional custom name for your RepStrap or other custom machine
@@ -235,12 +235,12 @@
  *
  * :{ '0': "Not used", '1':"100k / 4.7k - EPCOS", '2':"200k / 4.7k - ATC Semitec 204GT-2", '3':"Mendel-parts / 4.7k", '4':"10k !! do not use for a hotend. Bad resolution at high temp. !!", '5':"100K / 4.7k - ATC Semitec 104GT-2 (Used in ParCan & J-Head)", '6':"100k / 4.7k EPCOS - Not as accurate as Table 1", '7':"100k / 4.7k Honeywell 135-104LAG-J01", '8':"100k / 4.7k 0603 SMD Vishay NTCS0603E3104FXT", '9':"100k / 4.7k GE Sensing AL03006-58.2K-97-G1", '10':"100k / 4.7k RS 198-961", '11':"100k / 4.7k beta 3950 1%", '12':"100k / 4.7k 0603 SMD Vishay NTCS0603E3104FXT (calibrated for Makibox hot bed)", '13':"100k Hisens 3950  1% up to 300°C for hotend 'Simple ONE ' & hotend 'All In ONE'", '20':"PT100 (Ultimainboard V2.x)", '51':"100k / 1k - EPCOS", '52':"200k / 1k - ATC Semitec 204GT-2", '55':"100k / 1k - ATC Semitec 104GT-2 (Used in ParCan & J-Head)", '60':"100k Maker's Tool Works Kapton Bed Thermistor beta=3950", '66':"Dyze Design 4.7M High Temperature thermistor", '70':"the 100K thermistor found in the bq Hephestos 2", '71':"100k / 4.7k Honeywell 135-104LAF-J01", '147':"Pt100 / 4.7k", '1047':"Pt1000 / 4.7k", '110':"Pt100 / 1k (non-standard)", '1010':"Pt1000 / 1k (non standard)", '-3':"Thermocouple + MAX31855 (only for sensor 0)", '-2':"Thermocouple + MAX6675 (only for sensor 0)", '-1':"Thermocouple + AD595",'998':"Dummy 1", '999':"Dummy 2" }
  */
-#define TEMP_SENSOR_0 1
+#define TEMP_SENSOR_0 5
 #define TEMP_SENSOR_1 0
 #define TEMP_SENSOR_2 0
 #define TEMP_SENSOR_3 0
 #define TEMP_SENSOR_4 0
-#define TEMP_SENSOR_BED 0
+#define TEMP_SENSOR_BED 5
 
 // Dummy thermistor constant temperature readings, for use with 998 and 999
 #define DUMMY_THERMISTOR_998_VALUE 25
@@ -252,12 +252,12 @@
 #define MAX_REDUNDANT_TEMP_SENSOR_DIFF 10
 
 // Extruder temperature must be close to target for this long before M109 returns success
-#define TEMP_RESIDENCY_TIME 10  // (seconds)
+#define TEMP_RESIDENCY_TIME 6  // (seconds)
 #define TEMP_HYSTERESIS 3       // (degC) range of +/- temperatures considered "close" to the target one
 #define TEMP_WINDOW     1       // (degC) Window around target to start the residency timer x degC early.
 
 // Bed temperature must be close to target for this long before M190 returns success
-#define TEMP_BED_RESIDENCY_TIME 10  // (seconds)
+#define TEMP_BED_RESIDENCY_TIME 6  // (seconds)
 #define TEMP_BED_HYSTERESIS 3       // (degC) range of +/- temperatures considered "close" to the target one
 #define TEMP_BED_WINDOW     1       // (degC) Window around target to start the residency timer x degC early.
 
@@ -279,7 +279,7 @@
 #define HEATER_2_MAXTEMP 275
 #define HEATER_3_MAXTEMP 275
 #define HEATER_4_MAXTEMP 275
-#define BED_MAXTEMP 150
+#define BED_MAXTEMP 130
 
 //===========================================================================
 //============================= PID Settings ================================
@@ -297,15 +297,15 @@
   //#define SLOW_PWM_HEATERS // PWM with very low frequency (roughly 0.125Hz=8s) and minimum state time of approximately 1s useful for heaters driven by a relay
   //#define PID_PARAMS_PER_HOTEND // Uses separate PID parameters for each extruder (useful for mismatched extruders)
                                   // Set/get with gcode: M301 E[extruder number, 0-2]
-  #define PID_FUNCTIONAL_RANGE 10 // If the temperature difference between the target temperature and the actual temperature
+  #define PID_FUNCTIONAL_RANGE 15 // If the temperature difference between the target temperature and the actual temperature
                                   // is more than PID_FUNCTIONAL_RANGE then the PID will be shut off and the heater will be set to min/max.
   #define K1 0.95 //smoothing factor within the PID
 
   // If you are using a pre-configured hotend then you can use one of the value sets by uncommenting it
   // Ultimaker
-  #define  DEFAULT_Kp 22.2
-  #define  DEFAULT_Ki 1.08
-  #define  DEFAULT_Kd 114
+  //#define  DEFAULT_Kp 22.2
+  //#define  DEFAULT_Ki 1.08
+  //#define  DEFAULT_Kd 114
 
   // MakerGear
   //#define  DEFAULT_Kp 7.0
@@ -316,6 +316,12 @@
   //#define  DEFAULT_Kp 63.0
   //#define  DEFAULT_Ki 2.25
   //#define  DEFAULT_Kd 440
+
+  // ANET A8 Standard Extruder at 210 Degree Celsius and 100% Fan
+  //(measured after M106 S255 with M303 E0 S210 C8)
+  #define  DEFAULT_Kp 21.0
+  #define  DEFAULT_Ki 1.25
+  #define  DEFAULT_Kd 86.0
 
 #endif // PIDTEMP
 
@@ -333,7 +339,7 @@
 // If this is enabled, find your own PID constants below.
 //#define PIDTEMPBED
 
-//#define BED_LIMIT_SWITCHING
+#define BED_LIMIT_SWITCHING
 
 // This sets the max power delivered to the bed, and replaces the HEATER_BED_DUTY_CYCLE_DIVIDER option.
 // all forms of bed control obey this (PID, bang-bang, bang-bang with hysteresis)
@@ -439,13 +445,13 @@
 #endif
 
 // Mechanical endstop with COM to ground and NC to Signal uses "false" here (most common setup).
-#define X_MIN_ENDSTOP_INVERTING false // set to true to invert the logic of the endstop.
-#define Y_MIN_ENDSTOP_INVERTING false // set to true to invert the logic of the endstop.
-#define Z_MIN_ENDSTOP_INVERTING false // set to true to invert the logic of the endstop.
+#define X_MIN_ENDSTOP_INVERTING true // set to true to invert the logic of the endstop.
+#define Y_MIN_ENDSTOP_INVERTING true // set to true to invert the logic of the endstop.
+#define Z_MIN_ENDSTOP_INVERTING true // set to true to invert the logic of the endstop.
 #define X_MAX_ENDSTOP_INVERTING false // set to true to invert the logic of the endstop.
 #define Y_MAX_ENDSTOP_INVERTING false // set to true to invert the logic of the endstop.
 #define Z_MAX_ENDSTOP_INVERTING false // set to true to invert the logic of the endstop.
-#define Z_MIN_PROBE_ENDSTOP_INVERTING false // set to true to invert the logic of the probe.
+#define Z_MIN_PROBE_ENDSTOP_INVERTING true // set to true to invert the logic of the probe.
 
 // Enable this feature if all enabled endstop pins are interrupt-capable.
 // This will remove the need to poll the interrupt pins, saving many CPU cycles.
@@ -476,14 +482,14 @@
  * Override with M92
  *                                      X, Y, Z, E0 [, E1[, E2[, E3[, E4]]]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 4000, 500 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   {100,  100, 400,90}
 
 /**
  * Default Max Feed Rate (mm/s)
  * Override with M203
  *                                      X, Y, Z, E0 [, E1[, E2[, E3[, E4]]]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 300, 300, 5, 25 }
+#define DEFAULT_MAX_FEEDRATE          {400, 400, 8, 50}
 
 /**
  * Default Max Acceleration (change/s) change = mm/s
@@ -491,8 +497,7 @@
  * Override with M201
  *                                      X, Y, Z, E0 [, E1[, E2[, E3[, E4]]]]
  */
-#define DEFAULT_MAX_ACCELERATION      { 3000, 3000, 100, 10000 }
-
+#define DEFAULT_MAX_ACCELERATION      {3000,3000,1000,5000}
 /**
  * Default Acceleration (change/s) change = mm/s
  * Override with M204
@@ -501,7 +506,7 @@
  *   M204 R    Retract Acceleration
  *   M204 T    Travel Acceleration
  */
-#define DEFAULT_ACCELERATION          3000    // X, Y, Z and E acceleration for printing moves
+#define DEFAULT_ACCELERATION          1000    // X, Y, Z and E acceleration for printing moves
 #define DEFAULT_RETRACT_ACCELERATION  3000    // E acceleration for retracts
 #define DEFAULT_TRAVEL_ACCELERATION   3000    // X, Y, Z acceleration for travel (non printing) moves
 
@@ -575,7 +580,7 @@
  * A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
  *   (e.g., an inductive probe or a nozzle-based probe-switch.)
  */
-//#define FIX_MOUNTED_PROBE
+#define FIX_MOUNTED_PROBE
 
 /**
  * Z Servo Probe, such as an endstop switch on a rotating arm.
@@ -631,10 +636,21 @@
  *      O-- FRONT --+
  *    (0,0)
  */
-#define X_PROBE_OFFSET_FROM_EXTRUDER 10  // X offset: -left  +right  [of the nozzle]
-#define Y_PROBE_OFFSET_FROM_EXTRUDER 10  // Y offset: -front +behind [the nozzle]
+#define X_PROBE_OFFSET_FROM_EXTRUDER 0  // X offset: -left  +right  [of the nozzle]
+#define Y_PROBE_OFFSET_FROM_EXTRUDER 0  // Y offset: -front +behind [the nozzle]
 #define Z_PROBE_OFFSET_FROM_EXTRUDER 0   // Z offset: -below +above  [the nozzle]
 
+// BELOW IS FOR THE FRONT MOUNTED SENSOR WITH 3D PRINTED MOUNT
+//#define X_PROBE_OFFSET_FROM_EXTRUDER -28  // X offset: -left  +right  [of the nozzle]
+//#define Y_PROBE_OFFSET_FROM_EXTRUDER -45  // Y offset: -front +behind [the nozzle]
+//#define Z_PROBE_OFFSET_FROM_EXTRUDER 0   // Z offset: -below +above  [the nozzle]
+
+//AND THE LINES BELOW HERE ARE FOR THE OFFICIAL ANET REAR MOUNTED SENSOR
+//#define X_PROBE_OFFSET_FROM_EXTRUDER -1  // X offset: -left  +right  [of the nozzle]
+//#define Y_PROBE_OFFSET_FROM_EXTRUDER  3 // Y offset: -front +behind [the nozzle]
+//#define Z_PROBE_OFFSET_FROM_EXTRUDER 0   // Z offset: -below +above  [the nozzle]
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
 // X and Y axis travel speed (mm/m) between probes
 #define XY_PROBE_SPEED 8000
 
@@ -695,8 +711,8 @@
 
 // Invert the stepper direction. Change (or reverse the motor connector) if an axis goes the wrong way.
 #define INVERT_X_DIR false
-#define INVERT_Y_DIR true
-#define INVERT_Z_DIR false
+#define INVERT_Y_DIR false
+#define INVERT_Z_DIR true
 
 // Enable this option for Toshiba stepper drivers
 //#define CONFIG_STEPPERS_TOSHIBA
@@ -724,12 +740,12 @@
 // @section machine
 
 // Travel limits after homing (units are in mm)
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 200
-#define Y_MAX_POS 200
-#define Z_MAX_POS 200
+#define X_MAX_POS     220
+#define X_MIN_POS     -33
+#define Y_MAX_POS     220
+#define Y_MIN_POS     -10
+#define Z_MAX_POS     240
+#define Z_MIN_POS   0
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS
@@ -822,8 +838,8 @@
 
   // Set the boundaries for probing (where the probe can reach).
   #define LEFT_PROBE_BED_POSITION 15
-  #define RIGHT_PROBE_BED_POSITION 170
-  #define FRONT_PROBE_BED_POSITION 20
+  #define RIGHT_PROBE_BED_POSITION 190
+  #define FRONT_PROBE_BED_POSITION 15
   #define BACK_PROBE_BED_POSITION 170
 
   // The Z probe minimum outer margin (to validate G29 parameters).
@@ -854,12 +870,12 @@
 
   // 3 arbitrary points to probe.
   // A simple cross-product is used to estimate the plane of the bed.
-  #define ABL_PROBE_PT_1_X 15
-  #define ABL_PROBE_PT_1_Y 180
-  #define ABL_PROBE_PT_2_X 15
-  #define ABL_PROBE_PT_2_Y 20
-  #define ABL_PROBE_PT_3_X 170
-  #define ABL_PROBE_PT_3_Y 20
+  #define ABL_PROBE_PT_1_X 20//15
+  #define ABL_PROBE_PT_1_Y 160//180
+  #define ABL_PROBE_PT_2_X 20//15
+  #define ABL_PROBE_PT_2_Y 10//20
+  #define ABL_PROBE_PT_3_X 180//170
+  #define ABL_PROBE_PT_3_Y 10//20
 
 #elif ENABLED(AUTO_BED_LEVELING_UBL)
 
@@ -932,13 +948,13 @@
 //#define Z_SAFE_HOMING
 
 #if ENABLED(Z_SAFE_HOMING)
-  #define Z_SAFE_HOMING_X_POINT ((X_MIN_POS + X_MAX_POS) / 2)    // X point for Z homing when homing all axis (G28).
-  #define Z_SAFE_HOMING_Y_POINT ((Y_MIN_POS + Y_MAX_POS) / 2)    // Y point for Z homing when homing all axis (G28).
+  #define Z_SAFE_HOMING_X_POINT (X_MAX_POS / 2)    // X point for Z homing when homing all axis (G28).
+  #define Z_SAFE_HOMING_Y_POINT (Y_MAX_POS / 2)    // Y point for Z homing when homing all axis (G28).
 #endif
 
 // Homing speeds (mm/m)
 #define HOMING_FEEDRATE_XY (50*60)
-#define HOMING_FEEDRATE_Z  (4*60)
+#define HOMING_FEEDRATE_Z  (6*60)
 
 //=============================================================================
 //============================= Additional Features ===========================
@@ -954,7 +970,7 @@
 // M501 - reads parameters from EEPROM (if you need reset them after you changed them temporarily).
 // M502 - reverts to the default "factory settings".  You still need to store them in EEPROM afterwards if you want to.
 //define this to enable EEPROM support
-//#define EEPROM_SETTINGS
+#define EEPROM_SETTINGS
 
 #if ENABLED(EEPROM_SETTINGS)
   // To disable EEPROM Serial responses and decrease program space by ~1700 byte: comment this out:
@@ -967,8 +983,8 @@
 // When enabled Marlin will send a busy status message to the host
 // every couple of seconds when it can't accept commands.
 //
-#define HOST_KEEPALIVE_FEATURE        // Disable this if your host doesn't like keepalive messages
-#define DEFAULT_KEEPALIVE_INTERVAL 2  // Number of seconds between "busy" messages. Set with M113.
+//#define HOST_KEEPALIVE_FEATURE        // Disable this if your host doesn't like keepalive messages
+//#define DEFAULT_KEEPALIVE_INTERVAL 2  // Number of seconds between "busy" messages. Set with M113.
 
 //
 // M100 Free Memory Watcher
@@ -988,12 +1004,12 @@
 // @section temperature
 
 // Preheat Constants
-#define PREHEAT_1_TEMP_HOTEND 180
-#define PREHEAT_1_TEMP_BED     70
+#define PREHEAT_1_TEMP_HOTEND 190
+#define PREHEAT_1_TEMP_BED     60
 #define PREHEAT_1_FAN_SPEED     0 // Value from 0 to 255
 
 #define PREHEAT_2_TEMP_HOTEND 240
-#define PREHEAT_2_TEMP_BED    110
+#define PREHEAT_2_TEMP_BED    90
 #define PREHEAT_2_FAN_SPEED     0 // Value from 0 to 255
 
 /**
@@ -1162,6 +1178,11 @@
 //#define ULTRA_LCD   // Character based
 //#define DOGLCD      // Full graphics display
 
+#define ANET_KEYPAD_LCD
+//#define ANET_FULL_GRAPHICS_LCD
+// RepRap Discount (with Anet Adapter wiring see: http://www.thingiverse.com/thing:2103748)
+//#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
+
 /**
  * SD CARD
  *
@@ -1169,7 +1190,7 @@
  * you must uncomment the following option or it won't work.
  *
  */
-//#define SDSUPPORT
+#define SDSUPPORT
 
 /**
  * SD CARD: SPI SPEED
@@ -1343,7 +1364,9 @@
 // is pressed, a value of 10.0 means 10mm per click.
 //
 //#define REPRAPWORLD_KEYPAD
-//#define REPRAPWORLD_KEYPAD_MOVE_STEP 1.0
+//#define REPRAPWORLD_KEYPAD_MOVE_STEP 10.0
+//#define ADC_KEYPAD
+//#define ADC_KEYPAD_DEBUG
 
 //
 // RigidBot Panel V1.0

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -455,7 +455,7 @@
 
 // Enable this feature if all enabled endstop pins are interrupt-capable.
 // This will remove the need to poll the interrupt pins, saving many CPU cycles.
-//#define ENDSTOP_INTERRUPTS_FEATURE
+#define ENDSTOP_INTERRUPTS_FEATURE
 
 //=============================================================================
 //============================== Movement Settings ============================

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -482,7 +482,7 @@
  * Override with M92
  *                                      X, Y, Z, E0 [, E1[, E2[, E3[, E4]]]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   {100,  100, 400,90}
+#define DEFAULT_AXIS_STEPS_PER_UNIT   {100,  100, 400, 95}
 
 /**
  * Default Max Feed Rate (mm/s)
@@ -497,7 +497,7 @@
  * Override with M201
  *                                      X, Y, Z, E0 [, E1[, E2[, E3[, E4]]]]
  */
-#define DEFAULT_MAX_ACCELERATION      {3000,3000,1000,5000}
+#define DEFAULT_MAX_ACCELERATION      { 1000, 1000, 100, 5000 }
 /**
  * Default Acceleration (change/s) change = mm/s
  * Override with M204
@@ -506,9 +506,9 @@
  *   M204 R    Retract Acceleration
  *   M204 T    Travel Acceleration
  */
-#define DEFAULT_ACCELERATION          1000    // X, Y, Z and E acceleration for printing moves
-#define DEFAULT_RETRACT_ACCELERATION  3000    // E acceleration for retracts
-#define DEFAULT_TRAVEL_ACCELERATION   3000    // X, Y, Z acceleration for travel (non printing) moves
+#define DEFAULT_ACCELERATION          400     // X, Y, Z and E acceleration for printing moves
+#define DEFAULT_RETRACT_ACCELERATION  1000    // E acceleration for retracts
+#define DEFAULT_TRAVEL_ACCELERATION   400    // X, Y, Z acceleration for travel (non printing) moves
 
 /**
  * Default Jerk (mm/s)
@@ -520,7 +520,7 @@
  */
 #define DEFAULT_XJERK                 20.0
 #define DEFAULT_YJERK                 20.0
-#define DEFAULT_ZJERK                  0.4
+#define DEFAULT_ZJERK                  0.3
 #define DEFAULT_EJERK                  5.0
 
 
@@ -652,7 +652,7 @@
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // X and Y axis travel speed (mm/m) between probes
-#define XY_PROBE_SPEED 8000
+#define XY_PROBE_SPEED 6000
 
 // Speed for the first approach when double-probing (with PROBE_DOUBLE_TOUCH)
 #define Z_PROBE_SPEED_FAST HOMING_FEEDRATE_Z
@@ -811,7 +811,7 @@
  *   With an LCD controller the process is guided step-by-step.
  */
 //#define AUTO_BED_LEVELING_3POINT
-//#define AUTO_BED_LEVELING_LINEAR
+#define AUTO_BED_LEVELING_LINEAR
 //#define AUTO_BED_LEVELING_BILINEAR
 //#define AUTO_BED_LEVELING_UBL
 //#define MESH_BED_LEVELING
@@ -953,8 +953,8 @@
 #endif
 
 // Homing speeds (mm/m)
-#define HOMING_FEEDRATE_XY (50*60)
-#define HOMING_FEEDRATE_Z  (6*60)
+#define HOMING_FEEDRATE_XY (100*60)
+#define HOMING_FEEDRATE_Z  (4*60)
 
 //=============================================================================
 //============================= Additional Features ===========================

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -236,7 +236,7 @@
 
 // If you want endstops to stay on (by default) even when not homing
 // enable this option. Override at any time with M120, M121.
-//#define ENDSTOPS_ALWAYS_ON_DEFAULT
+#define ENDSTOPS_ALWAYS_ON_DEFAULT
 
 // @section extras
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -62,8 +62,8 @@
  * If you get false positives for "Thermal Runaway" increase THERMAL_PROTECTION_HYSTERESIS and/or THERMAL_PROTECTION_PERIOD
  */
 #if ENABLED(THERMAL_PROTECTION_HOTENDS)
-  #define THERMAL_PROTECTION_PERIOD 40        // Seconds
-  #define THERMAL_PROTECTION_HYSTERESIS 4     // Degrees Celsius
+  #define THERMAL_PROTECTION_PERIOD 60        // Seconds
+  #define THERMAL_PROTECTION_HYSTERESIS 10    // Degrees Celsius
 
   /**
    * Whenever an M104 or M109 increases the target temperature the firmware will wait for the
@@ -82,8 +82,8 @@
  * Thermal Protection parameters for the bed are just as above for hotends.
  */
 #if ENABLED(THERMAL_PROTECTION_BED)
-  #define THERMAL_PROTECTION_BED_PERIOD 20    // Seconds
-  #define THERMAL_PROTECTION_BED_HYSTERESIS 2 // Degrees Celsius
+  #define THERMAL_PROTECTION_BED_PERIOD 60    // Seconds
+  #define THERMAL_PROTECTION_BED_HYSTERESIS 5 // Degrees Celsius
 
   /**
    * Whenever an M140 or M190 increases the target temperature the firmware will wait for the
@@ -94,7 +94,7 @@
    * If you get too many "Heating failed" errors, increase WATCH_BED_TEMP_PERIOD and/or decrease
    * WATCH_BED_TEMP_INCREASE. (WATCH_BED_TEMP_INCREASE should not be below 2.)
    */
-  #define WATCH_BED_TEMP_PERIOD 60                // Seconds
+  #define WATCH_BED_TEMP_PERIOD 180                // Seconds
   #define WATCH_BED_TEMP_INCREASE 2               // Degrees Celsius
 #endif
 
@@ -118,7 +118,7 @@
  * Also, if the temperature is set to a value below mintemp, it will not be changed by autotemp.
  * On an Ultimaker, some initial testing worked with M109 S215 B260 F1 in the start.gcode
  */
-#define AUTOTEMP
+//#define AUTOTEMP
 #if ENABLED(AUTOTEMP)
   #define AUTOTEMP_OLDWEIGHT 0.98
 #endif
@@ -453,7 +453,7 @@
   // as SD_DETECT_PIN in your board's pins definitions.
   // This setting should be disabled unless you are using a push button, pulling the pin to ground.
   // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
-  #define SD_DETECT_INVERTED
+  //#define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
@@ -670,7 +670,7 @@
 // @section extras
 
 // Arc interpretation settings:
-#define ARC_SUPPORT  // Disabling this saves ~2738 bytes
+//#define ARC_SUPPORT  // Disabling this saves ~2738 bytes
 #define MM_PER_ARC_SEGMENT 1
 #define N_ARC_CORRECTION 25
 
@@ -1166,3 +1166,4 @@
 //#define NO_WORKSPACE_OFFSETS
 
 #endif // CONFIGURATION_ADV_H
+

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4902,7 +4902,7 @@ void home_all_axes() { gcode_G28(); }
             NOMORE(min_diff, eqnBVector[ind] - z_tmp);
 
             if (diff >= 0.0)
-              SERIAL_PROTOCOLPGM(" +");   // Include + for column alignment
+              SERIAL_PROTOCOLPGM("  ");   // Include + for column alignment
             else
               SERIAL_PROTOCOLCHAR(' ');
             SERIAL_PROTOCOL_F(diff, 5);
@@ -4925,7 +4925,7 @@ void home_all_axes() { gcode_G28(); }
 
               float diff = eqnBVector[ind] - z_tmp - min_diff;
               if (diff >= 0.0)
-                SERIAL_PROTOCOLPGM(" +");
+                SERIAL_PROTOCOLPGM("  ");
               // Include + for column alignment
               else
                 SERIAL_PROTOCOLCHAR(' ');

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -1127,3 +1127,10 @@ static_assert(COUNT(sanity_arr_3) >= XYZE, "DEFAULT_MAX_ACCELERATION requires 4 
 static_assert(COUNT(sanity_arr_1) <= XYZE_N, "DEFAULT_AXIS_STEPS_PER_UNIT has too many elements.");
 static_assert(COUNT(sanity_arr_2) <= XYZE_N, "DEFAULT_MAX_FEEDRATE has too many elements.");
 static_assert(COUNT(sanity_arr_3) <= XYZE_N, "DEFAULT_MAX_ACCELERATION has too many elements.");
+
+/**
+ * Make sure valid pin is used for ADC Key Pad.
+*/
+#if ENABLED(ADC_KEYPAD) && !defined(ADC_KEYPAD_PIN)
+  #error "ADC_KEYPAD need to set a pin for ADC_KEYPAD_PIN. Please update your configuration."
+#endif

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -35,7 +35,7 @@
   /**
    * Marlin release version identifier
    */
-  #define SHORT_BUILD_VERSION "1.1.0-1"
+  #define SHORT_BUILD_VERSION "SkyNet3D-1.1.0-1"
 
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -70,7 +70,7 @@
   /**
    * Defines a generic printer name to be output to the LCD after booting Marlin.
    */
-  #define MACHINE_NAME "3D Printer"
+  #define MACHINE_NAME "SkyNet3D"
 
   /**
    * The SOURCE_CODE_URL is the location where users will find the Marlin Source

--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -59,6 +59,7 @@
 #define BOARD_MELZI_MAKR3D      66   // Melzi with ATmega1284 (MaKr3d version)
 #define BOARD_AZTEEG_X3         67   // Azteeg X3
 #define BOARD_AZTEEG_X3_PRO     68   // Azteeg X3 Pro
+#define BOARD_ANET_10           69   // Anet 1.0 (Melzi clone)
 #define BOARD_ULTIMAKER         7    // Ultimaker
 #define BOARD_ULTIMAKER_OLD     71   // Ultimaker (Older electronics. Pre 1.5.4. This is rare)
 #define BOARD_ULTIMAIN_2        72   // Ultimainboard 2.x (Uses TEMP_SENSOR 20)

--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -96,6 +96,7 @@
 #define BOARD_BAM_DICE          401  // 2PrintBeta BAM&DICE with STK drivers
 #define BOARD_BAM_DICE_DUE      402  // 2PrintBeta BAM&DICE Due with STK drivers
 #define BOARD_BQ_ZUM_MEGA_3D    503  // bq ZUM Mega 3D
+#define BOARD_ANET_10			100  // Anet v1.0
 
 #define MB(board) (MOTHERBOARD==BOARD_##board)
 

--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -96,7 +96,6 @@
 #define BOARD_BAM_DICE          401  // 2PrintBeta BAM&DICE with STK drivers
 #define BOARD_BAM_DICE_DUE      402  // 2PrintBeta BAM&DICE Due with STK drivers
 #define BOARD_BQ_ZUM_MEGA_3D    503  // bq ZUM Mega 3D
-#define BOARD_ANET_10			100  // Anet v1.0
 
 #define MB(board) (MOTHERBOARD==BOARD_##board)
 

--- a/Marlin/enum.h
+++ b/Marlin/enum.h
@@ -170,3 +170,4 @@ enum LCDViewAction {
 #endif
 
 #endif // __ENUM_H__
+

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -176,6 +176,8 @@
   #include "pins_MKS_13.h"
 #elif MB(SAINSMART_2IN1)
   #include "pins_SAINSMART_2IN1.h"
+#elif MB(ANET_10)
+  #include "pins_ANET_10.h"
 #else
   #error "Unknown MOTHERBOARD value set in Configuration.h"
 #endif

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -176,8 +176,6 @@
   #include "pins_MKS_13.h"
 #elif MB(SAINSMART_2IN1)
   #include "pins_SAINSMART_2IN1.h"
-#elif MB(ANET_10)
-  #include "pins_ANET_10.h"
 #else
   #error "Unknown MOTHERBOARD value set in Configuration.h"
 #endif

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -95,6 +95,8 @@
   #include "pins_AZTEEG_X3.h"
 #elif MB(AZTEEG_X3_PRO)
   #include "pins_AZTEEG_X3_PRO.h"
+#elif MB(ANET_10)
+  #include "pins_ANET_10.h"
 #elif MB(ULTIMAKER)
   #include "pins_ULTIMAKER.h"
 #elif MB(ULTIMAKER_OLD)
@@ -569,3 +571,4 @@
 #endif
 
 #endif //__PINS_H
+

--- a/Marlin/pins_ANET_10.h
+++ b/Marlin/pins_ANET_10.h
@@ -1,0 +1,105 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Anet board pin assignments
+ */
+
+#if defined(__AVR_ATmega1284P__)
+#define VARIANT_STANDARD true
+#endif
+
+#include "pins_SANGUINOLOLU_12.h"
+
+#undef BOARD_NAME
+#define BOARD_NAME "Anet"
+
+#undef LED_PIN
+#undef FAN_PIN
+
+#define FAN_PIN 4
+
+#if ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL)
+  #undef LCD_PINS_RS
+  #undef LCD_PINS_ENABLE
+  #undef LCD_PINS_D4
+  #undef LCD_PINS_D5
+  #undef LCD_PINS_D6
+  #undef LCD_PINS_D7
+
+  #if ENABLED(ADC_KEYPAD)
+    #undef BTN_EN1
+    #undef BTN_EN2
+    #undef BTN_ENC
+
+    #define SERVO0_PIN         27 // free for BLTouch/3D-Touch
+    #define LCD_PINS_RS        28
+    #define LCD_PINS_ENABLE    29
+    #define LCD_PINS_D4        10
+    #define LCD_PINS_D5        11
+    #define LCD_PINS_D6        16
+    #define LCD_PINS_D7        17
+
+    #define BTN_EN1            -1
+    #define BTN_EN2            -1
+    #define BTN_ENC            -1
+
+    #define ADC_KEYPAD_PIN      1
+
+    #define ENCODER_FEEDRATE_DEADZONE 2
+  #elif ENABLED(U8GLIB_ST7920)
+    #undef BEEPER_PIN
+
+  #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
+    // For RepRap Discount (with Anet Adapter wiring)
+    #define SERVO0_PIN        27 // free for BLTouch/3D-Touch
+    #define BEEPER_PIN        28
+    #define LCD_PINS_RS       30
+    #define	LCD_PINS_ENABLE   29
+    #define LCD_PINS_D4       17
+    #define BTN_EN1               11
+    #define BTN_EN2               10
+  #elif ENABLED(ANET_FULL_GRAPHICS_LCD)
+    #define SERVO0_PIN         29 // free for BLTouch/3D-Touch
+    #define BEEPER_PIN 17
+    #define LCD_PINS_RS        27
+    #define LCD_PINS_ENABLE    28
+    #define LCD_PINS_D4        30
+  #else
+    #error "You need to select ANET or RepRap Version"
+  #endif
+
+    #define ST7920_DELAY_1 DELAY_0_NOP
+    #define ST7920_DELAY_2 DELAY_1_NOP
+    #define ST7920_DELAY_3 DELAY_2_NOP
+
+    #ifndef ENCODER_STEPS_PER_MENU_ITEM
+      #define ENCODER_STEPS_PER_MENU_ITEM 1
+    #endif
+    #ifndef ENCODER_PULSES_PER_STEP
+      #define ENCODER_PULSES_PER_STEP 4
+    #endif
+  #endif
+
+#endif
+
+

--- a/Marlin/pins_ANET_10.h
+++ b/Marlin/pins_ANET_10.h
@@ -32,9 +32,6 @@
 
 #include "pins_SANGUINOLOLU_12.h"
 
-#undef BOARD_NAME
-#define BOARD_NAME "Anet"
-
 #undef LED_PIN
 #undef FAN_PIN
 

--- a/Marlin/pins_ANET_10.h
+++ b/Marlin/pins_ANET_10.h
@@ -24,6 +24,8 @@
  * Anet board pin assignments
  */
 
+#define BOARD_NAME "Anet"
+
 #if defined(__AVR_ATmega1284P__)
 #define VARIANT_STANDARD true
 #endif
@@ -91,15 +93,7 @@
     #define ST7920_DELAY_1 DELAY_0_NOP
     #define ST7920_DELAY_2 DELAY_1_NOP
     #define ST7920_DELAY_3 DELAY_2_NOP
-
-    #ifndef ENCODER_STEPS_PER_MENU_ITEM
-      #define ENCODER_STEPS_PER_MENU_ITEM 1
-    #endif
-    #ifndef ENCODER_PULSES_PER_STEP
-      #define ENCODER_PULSES_PER_STEP 4
-    #endif
   #endif
 
 #endif
-
 

--- a/Marlin/pins_SANGUINOLOLU_11.h
+++ b/Marlin/pins_SANGUINOLOLU_11.h
@@ -32,7 +32,7 @@
   #define BOARD_NAME "Sanguinololu <1.2"
 #endif
 
-#define IS_MELZI (MB(MELZI) || MB(MELZI_MAKR3D))
+#define IS_MELZI (MB(MELZI) || MB(MELZI_MAKR3D) || MB(ANET_10))
 
 //
 // Limit Switches

--- a/Marlin/pins_SANGUINOLOLU_12.h
+++ b/Marlin/pins_SANGUINOLOLU_12.h
@@ -32,7 +32,9 @@
  *  STB_11
  */
 
-#define BOARD_NAME "Sanguinololu 1.2"
+#ifndef BOARD_NAME
+  #define BOARD_NAME "Sanguinololu 1.2"
+#endif
 
 #ifdef __AVR_ATmega1284P__
   #define LARGE_FLASH true

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -217,6 +217,11 @@ uint8_t Temperature::soft_pwm[HOTENDS];
   uint8_t Temperature::ADCKey_count = 0;
 #endif
 
+#if ENABLED(ADC_KEYPAD)
+  uint32_t Temperature::current_ADCKey_raw = 0;
+  uint8_t Temperature::ADCKey_count = 0;
+#endif
+
 #if HAS_PID_HEATING
 
   void Temperature::PID_autotune(float temp, int hotend, int ncycles, bool set_result/*=false*/) {

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -2000,8 +2000,8 @@ void Temperature::isr() {
           raw_filwidth_value -= (raw_filwidth_value >> 7); // Subtract 1/128th of the raw_filwidth_value
           raw_filwidth_value += ((unsigned long)ADC << 7); // Add new ADC reading, scaled by 128
         }
-        break;
-    #endif
+      break;
+	#endif
 
     #if ENABLED(ADC_KEYPAD)
       case Prepare_ADC_KEY:

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1624,6 +1624,7 @@ void Temperature::isr() {
   static uint8_t pwm_count = _BV(SOFT_PWM_SCALE);
   // avoid multiple loads of pwm_count
   uint8_t pwm_count_tmp = pwm_count;
+
   #if ENABLED(ADC_KEYPAD)
     static unsigned int raw_ADCKey_value = 0;
   #endif
@@ -1999,7 +2000,7 @@ void Temperature::isr() {
           raw_filwidth_value -= (raw_filwidth_value >> 7); // Subtract 1/128th of the raw_filwidth_value
           raw_filwidth_value += ((unsigned long)ADC << 7); // Add new ADC reading, scaled by 128
         }
-      break;
+        break;
     #endif
 
     #if ENABLED(ADC_KEYPAD)

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -212,6 +212,11 @@ uint8_t Temperature::soft_pwm[HOTENDS];
   #endif
 #endif
 
+#if ENABLED(ADC_KEYPAD)
+  uint32_t Temperature::current_ADCKey_raw = 0;
+  uint8_t Temperature::ADCKey_count = 0;
+#endif
+
 #if HAS_PID_HEATING
 
   void Temperature::PID_autotune(float temp, int hotend, int ncycles, bool set_result/*=false*/) {
@@ -1614,6 +1619,9 @@ void Temperature::isr() {
   static uint8_t pwm_count = _BV(SOFT_PWM_SCALE);
   // avoid multiple loads of pwm_count
   uint8_t pwm_count_tmp = pwm_count;
+  #if ENABLED(ADC_KEYPAD)
+    static unsigned int raw_ADCKey_value = 0;
+  #endif
 
   // Static members for each heater
   #if ENABLED(SLOW_PWM_HEATERS)
@@ -1985,6 +1993,27 @@ void Temperature::isr() {
         if (ADC > 102) { // Make sure ADC is reading > 0.5 volts, otherwise don't read.
           raw_filwidth_value -= (raw_filwidth_value >> 7); // Subtract 1/128th of the raw_filwidth_value
           raw_filwidth_value += ((unsigned long)ADC << 7); // Add new ADC reading, scaled by 128
+        }
+      break;
+    #endif
+
+    #if ENABLED(ADC_KEYPAD)
+      case Prepare_ADC_KEY:
+        START_ADC(ADC_KEYPAD_PIN);
+        break;
+
+      case Measure_ADC_KEY:
+        if (ADCKey_count < 16) {
+          raw_ADCKey_value = ADC;
+          if (raw_ADCKey_value > 900) {
+            //ADC Key release
+            ADCKey_count = 0;
+            current_ADCKey_raw = 0;
+          }
+          else {
+            current_ADCKey_raw += raw_ADCKey_value;
+            ADCKey_count++;
+          }
         }
         break;
     #endif

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -81,6 +81,10 @@ enum ADCSensorState {
     Prepare_FILWIDTH,
     Measure_FILWIDTH,
   #endif
+  #if ENABLED(ADC_KEYPAD)
+    Prepare_ADC_KEY,
+    Measure_ADC_KEY,
+  #endif
   SensorsReady, // Temperatures ready. Delay the next round of readings to let ADC pins settle.
   StartupDelay  // Startup, delay initial temp reading a tiny bit so the hardware can settle
 };
@@ -269,6 +273,10 @@ class Temperature {
     #endif
 
   public:
+    #if ENABLED(ADC_KEYPAD)
+      static uint32_t current_ADCKey_raw;
+      static uint8_t ADCKey_count;
+    #endif
 
     /**
      * Instance Methods

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -396,7 +396,7 @@ uint16_t max_display_update_time = 0;
   bool lcd_clicked, wait_for_unclick;
   volatile uint8_t buttons;
   millis_t next_button_update_ms;
-  #if ENABLED(REPRAPWORLD_KEYPAD)
+  #if ENABLED(REPRAPWORLD_KEYPAD) || ENABLED(ADC_KEYPAD)
     volatile uint8_t buttons_reprapworld_keypad;
   #endif
   #if ENABLED(LCD_HAS_SLOW_BUTTONS)
@@ -3205,7 +3205,7 @@ void kill_screen(const char* lcd_msg) {
    * Handlers for RepRap World Keypad input
    *
    */
-  #if ENABLED(REPRAPWORLD_KEYPAD)
+  #if ENABLED(REPRAPWORLD_KEYPAD) && !ENABLED(ADC_KEYPAD)
     void _reprapworld_keypad_move(AxisEnum axis, int dir) {
       move_menu_scale = REPRAPWORLD_KEYPAD_MOVE_STEP;
       encoderPosition = dir;
@@ -3316,7 +3316,7 @@ void lcd_init() {
       SET_INPUT_PULLUP(BTN_ENC);
     #endif
 
-    #if ENABLED(REPRAPWORLD_KEYPAD)
+    #if ENABLED(REPRAPWORLD_KEYPAD) && DISABLED(ADC_KEYPAD)
       SET_OUTPUT(SHIFT_CLK);
       OUT_WRITE(SHIFT_LD, HIGH);
       SET_INPUT_PULLUP(SHIFT_OUT);
@@ -3504,9 +3504,59 @@ void lcd_update() {
         slow_buttons = lcd_implementation_read_slow_buttons(); // buttons which take too long to read in interrupt context
       #endif
 
-      #if ENABLED(REPRAPWORLD_KEYPAD)
-        handle_reprapworld_keypad();
+    #if ENABLED(ADC_KEYPAD)
+      static uint8_t adc_steps = 0;
+      if (buttons_reprapworld_keypad != 0)
+      {
+        adc_steps++;
+        if(adc_steps > 20)
+          adc_steps = 20;
+
+        lcd_quick_feedback();
+        lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
+        return_to_status_ms = millis() + LCD_TIMEOUT_TO_STATUS;
+        if (encoderDirection == -1) // side effect which signals we are inside a menu
+        {
+          if (buttons_reprapworld_keypad&EN_REPRAPWORLD_KEYPAD_DOWN)
+            encoderPosition -= ENCODER_STEPS_PER_MENU_ITEM;
+          else if (buttons_reprapworld_keypad&EN_REPRAPWORLD_KEYPAD_UP)
+            encoderPosition += ENCODER_STEPS_PER_MENU_ITEM;
+          else if (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_LEFT)
+            menu_action_back();
+          else if (buttons_reprapworld_keypad&EN_REPRAPWORLD_KEYPAD_RIGHT)
+            // enqueue_and_echo_commands_P(PSTR("M0 Pause"));
+            lcd_return_to_status();
+        }
+        else
+        {
+          int8_t step = 1;
+          if (adc_steps > 10)
+            step = 10;
+          if (adc_steps > 19)
+            step = 100;
+          if (buttons_reprapworld_keypad&EN_REPRAPWORLD_KEYPAD_DOWN)
+            encoderPosition += ENCODER_PULSES_PER_STEP  * step;
+          else if (buttons_reprapworld_keypad&EN_REPRAPWORLD_KEYPAD_UP)
+            encoderPosition -= ENCODER_PULSES_PER_STEP  * step;
+          else if (buttons_reprapworld_keypad&EN_REPRAPWORLD_KEYPAD_RIGHT)
+            encoderPosition = 0;
+        }
+      #ifdef ADC_KEYPAD_DEBUG
+        SERIAL_PROTOCOLPGM("buttons_reprapworld_keypad = ");
+        SERIAL_PROTOCOLLN((unsigned long)buttons_reprapworld_keypad);
+        SERIAL_PROTOCOLPGM("encoderPosition = ");
+        SERIAL_PROTOCOLLN((unsigned long)encoderPosition);
       #endif
+      }
+      else if(!thermalManager.current_ADCKey_raw)
+      {
+        // reset stepping acceleration
+        adc_steps = 0;
+      }
+
+    #elif ENABLED(REPRAPWORLD_KEYPAD)
+      handle_reprapworld_keypad();
+    #endif
 
       bool encoderPastThreshold = (abs(encoderDiff) >= ENCODER_PULSES_PER_STEP);
       if (encoderPastThreshold || lcd_clicked) {
@@ -3591,6 +3641,11 @@ void lcd_update() {
               break;
           } // switch
         }
+
+      #ifdef ADC_KEYPAD
+        buttons_reprapworld_keypad = 0;
+      #endif
+
       #if ENABLED(ULTIPANEL)
         #define CURRENTSCREEN() (*currentScreen)(), lcd_clicked = false
       #else
@@ -3824,8 +3879,18 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
         #if ENABLED(LCD_HAS_SLOW_BUTTONS)
           buttons |= slow_buttons;
         #endif
-        #if ENABLED(REPRAPWORLD_KEYPAD)
+        #if ENABLED(REPRAPWORLD_KEYPAD) && DISABLED(ADC_KEYPAD)
           GET_BUTTON_STATES(buttons_reprapworld_keypad);
+        #elif ENABLED(REPRAPWORLD_KEYPAD) && ENABLED(ADC_KEYPAD)
+          // for the anet adc_keypad
+          uint8_t newbutton_reprapworld_keypad = 0;
+          buttons = 0;
+          if (buttons_reprapworld_keypad == 0)
+          {
+            newbutton_reprapworld_keypad = get_ADC_keyValue();
+            if ((newbutton_reprapworld_keypad > 0) && (newbutton_reprapworld_keypad <= 8))
+              buttons_reprapworld_keypad = 1 << (newbutton_reprapworld_keypad - 1);
+          }
         #endif
       #else
         GET_BUTTON_STATES(buttons);
@@ -3891,5 +3956,50 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
   #endif
 
 #endif // ULTIPANEL
+
+#if ENABLED(ADC_KEYPAD)
+  #define	ADC_KEY_NUM		8
+  typedef struct
+  {
+    unsigned short ADCKeyValueMin;
+    unsigned short ADCKeyValueMax;
+    unsigned char  ADCKeyNo;
+  }_stADCKeypadTable_;
+  _stADCKeypadTable_ stADCKeyTable[ADC_KEY_NUM] =
+  {
+    //VALUE_MIN, VALUE_MAX , KEY
+    { 4000,4096, BLEN_REPRAPWORLD_KEYPAD_F1 + 1 }, //F1
+    { 4000,4096, BLEN_REPRAPWORLD_KEYPAD_F2 + 1 }, //F2
+    { 4000,4096, BLEN_REPRAPWORLD_KEYPAD_F3 + 1 }, //F3
+    { 300,500, 	BLEN_REPRAPWORLD_KEYPAD_LEFT + 1 }, //LEFT
+    { 1900,2200, BLEN_REPRAPWORLD_KEYPAD_RIGHT + 1 }, //RIGHT
+    { 570,870, 	BLEN_REPRAPWORLD_KEYPAD_UP + 1 }, //UP
+    { 2670,2870, BLEN_REPRAPWORLD_KEYPAD_DOWN + 1 }, //DOWN
+    { 1150,1450, BLEN_REPRAPWORLD_KEYPAD_MIDDLE + 1 }, //ENTER
+  };
+
+  unsigned char get_ADC_keyValue(void)
+  {
+    if (thermalManager.ADCKey_count >= 16)
+    {
+      unsigned short currentkpADCValue = (thermalManager.current_ADCKey_raw >> 2);
+      // Uncomment following line to debug the values
+      //SERIAL_PROTOCOLLN(currentkpADCValue);
+      thermalManager.current_ADCKey_raw = 0;
+      thermalManager.ADCKey_count = 0;
+      if (currentkpADCValue < 4000)
+      {
+        for (unsigned char i = 0; i<ADC_KEY_NUM; i++)
+        {
+          if ((currentkpADCValue > stADCKeyTable[i].ADCKeyValueMin) && (currentkpADCValue < stADCKeyTable[i].ADCKeyValueMax))
+          {
+            return stADCKeyTable[i].ADCKeyNo;
+          }
+        }
+      }
+    }
+    return 0;
+  }
+#endif
 
 #endif // ULTRA_LCD

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -54,6 +54,10 @@
     void dontExpireStatus();
   #endif
 
+  #if ENABLED(ADC_KEYPAD)
+    uint8_t get_ADC_keyValue();
+  #endif
+
   #if ENABLED(DOGLCD)
     extern int lcd_contrast;
     void set_lcd_contrast(int value);
@@ -123,12 +127,29 @@
 
     #define REPRAPWORLD_KEYPAD_MOVE_Z_DOWN  (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F3)
     #define REPRAPWORLD_KEYPAD_MOVE_Z_UP    (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F2)
-    #define REPRAPWORLD_KEYPAD_MOVE_MENU    (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F1)
     #define REPRAPWORLD_KEYPAD_MOVE_Y_DOWN  (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_DOWN)
     #define REPRAPWORLD_KEYPAD_MOVE_X_RIGHT (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_RIGHT)
-    #define REPRAPWORLD_KEYPAD_MOVE_HOME    (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_MIDDLE)
     #define REPRAPWORLD_KEYPAD_MOVE_Y_UP    (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_UP)
     #define REPRAPWORLD_KEYPAD_MOVE_X_LEFT  (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_LEFT)
+
+    #if ENABLED(ADC_KEYPAD)
+      #define REPRAPWORLD_KEYPAD_MOVE_HOME    (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F1)
+      #define REPRAPWORLD_KEYPAD_MOVE_MENU    (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_MIDDLE)
+
+      #if BUTTON_EXISTS(ENC)
+        #define LCD_CLICKED ((buttons & EN_C) || (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_MIDDLE))
+      #else
+        #define LCD_CLICKED (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_MIDDLE)
+      #endif
+    #else
+      #define REPRAPWORLD_KEYPAD_MOVE_HOME    (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_MIDDLE)
+      #define REPRAPWORLD_KEYPAD_MOVE_MENU    (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F1)
+      #if BUTTON_EXISTS(ENC)
+        #define LCD_CLICKED ((buttons & EN_C) || (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F1))
+      #else
+        #define LCD_CLICKED (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F1)
+      #endif
+    #endif
 
     #define REPRAPWORLD_KEYPAD_PRESSED      (buttons_reprapworld_keypad & ( \
                                               EN_REPRAPWORLD_KEYPAD_F3 | \
@@ -140,9 +161,8 @@
                                               EN_REPRAPWORLD_KEYPAD_UP | \
                                               EN_REPRAPWORLD_KEYPAD_LEFT) \
                                             )
-
-    #define LCD_CLICKED ((buttons & EN_C) || (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F1))
   #elif ENABLED(NEWPANEL)
+	#define REPRAPWORLD_KEYPAD_MOVE_X_RIGHT false
     #define LCD_CLICKED (buttons & EN_C)
   #else
     #define LCD_CLICKED false


### PR DESCRIPTION
I changed tabs to spaces and improved/made brackets like main dev.

Not sure about this warning here if this also for main dev is happening (used your config).
Also this PR #6380 was as about -fpermissive.

In file included from C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:68:0:

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:878:134: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                      ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:889:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(int, int3, itostr3);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:881:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_callback_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:889:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(int, int3, itostr3);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:889:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(int, int3, itostr3);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:185: warning: unused parameter 'pset' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                                                                         ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:889:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(int, int3, itostr3);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:878:134: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                      ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:890:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float3, ftostr3);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:881:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_callback_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:890:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float3, ftostr3);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:890:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float3, ftostr3);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:185: warning: unused parameter 'pset' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                                                                         ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:890:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float3, ftostr3);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:878:134: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                      ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:891:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float32, ftostr32);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:881:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_callback_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:891:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float32, ftostr32);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:891:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float32, ftostr32);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:185: warning: unused parameter 'pset' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                                                                         ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:891:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float32, ftostr32);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:878:134: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                      ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:892:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float43, ftostr43sign);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:881:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_callback_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:892:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float43, ftostr43sign);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:892:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float43, ftostr43sign);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:185: warning: unused parameter 'pset' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                                                                         ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:892:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float43, ftostr43sign);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:878:134: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                      ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:893:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float5, ftostr5rj);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:881:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_callback_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:893:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float5, ftostr5rj);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:893:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float5, ftostr5rj);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:185: warning: unused parameter 'pset' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                                                                         ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:893:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float5, ftostr5rj);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:878:134: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                      ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:894:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float51, ftostr51sign);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:881:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_callback_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:894:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float51, ftostr51sign);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:894:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float51, ftostr51sign);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:185: warning: unused parameter 'pset' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                                                                         ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:894:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float51, ftostr51sign);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:878:134: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                      ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:895:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float52, ftostr52sign);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:881:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_callback_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:895:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float52, ftostr52sign);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:895:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float52, ftostr52sign);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:185: warning: unused parameter 'pset' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                                                                         ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:895:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float52, ftostr52sign);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:878:134: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                      ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:896:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float62, ftostr62rj);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:881:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_callback_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:896:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float62, ftostr62rj);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:896:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float62, ftostr62rj);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:185: warning: unused parameter 'pset' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                                                                         ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:896:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float62, ftostr62rj);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:878:134: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                      ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:897:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(unsigned long, long5, ftostr5rj);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:881:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_callback_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:897:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(unsigned long, long5, ftostr5rj);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:143: warning: unused parameter 'pstr2' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                               ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:897:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(unsigned long, long5, ftostr5rj);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:884:185: warning: unused parameter 'pset' [-Wunused-parameter]

     inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \

                                                                                                                                                                                         ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd_impl_HD44780.h:897:3: note: in expansion of macro 'DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE'

   DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(unsigned long, long5, ftostr5rj);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp: In function 'void _menu_action_setting_edit_accessor_int3(const char*, int (*)(), void (*)(int), int, int)':

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3195:18: warning: invalid conversion from 'void (*)(int)' to 'void*' [-fpermissive]

       editSetter = pset; \

                  ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3206:3: note: in expansion of macro 'DEFINE_MENU_EDIT_TYPE'

   DEFINE_MENU_EDIT_TYPE(int, int3, itostr3, 1);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp: In function 'void _menu_action_setting_edit_accessor_float3(const char*, float (*)(), void (*)(float), float, float)':

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3195:18: warning: invalid conversion from 'void (*)(float)' to 'void*' [-fpermissive]

       editSetter = pset; \

                  ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3207:3: note: in expansion of macro 'DEFINE_MENU_EDIT_TYPE'

   DEFINE_MENU_EDIT_TYPE(float, float3, ftostr3, 1.0);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp: In function 'void _menu_action_setting_edit_accessor_float32(const char*, float (*)(), void (*)(float), float, float)':

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3195:18: warning: invalid conversion from 'void (*)(float)' to 'void*' [-fpermissive]

       editSetter = pset; \

                  ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3208:3: note: in expansion of macro 'DEFINE_MENU_EDIT_TYPE'

   DEFINE_MENU_EDIT_TYPE(float, float32, ftostr32, 100.0);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp: In function 'void _menu_action_setting_edit_accessor_float43(const char*, float (*)(), void (*)(float), float, float)':

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3195:18: warning: invalid conversion from 'void (*)(float)' to 'void*' [-fpermissive]

       editSetter = pset; \

                  ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3209:3: note: in expansion of macro 'DEFINE_MENU_EDIT_TYPE'

   DEFINE_MENU_EDIT_TYPE(float, float43, ftostr43sign, 1000.0);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp: In function 'void _menu_action_setting_edit_accessor_float5(const char*, float (*)(), void (*)(float), float, float)':

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3195:18: warning: invalid conversion from 'void (*)(float)' to 'void*' [-fpermissive]

       editSetter = pset; \

                  ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3210:3: note: in expansion of macro 'DEFINE_MENU_EDIT_TYPE'

   DEFINE_MENU_EDIT_TYPE(float, float5, ftostr5rj, 0.01);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp: In function 'void _menu_action_setting_edit_accessor_float51(const char*, float (*)(), void (*)(float), float, float)':

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3195:18: warning: invalid conversion from 'void (*)(float)' to 'void*' [-fpermissive]

       editSetter = pset; \

                  ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3211:3: note: in expansion of macro 'DEFINE_MENU_EDIT_TYPE'

   DEFINE_MENU_EDIT_TYPE(float, float51, ftostr51sign, 10.0);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp: In function 'void _menu_action_setting_edit_accessor_float52(const char*, float (*)(), void (*)(float), float, float)':

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3195:18: warning: invalid conversion from 'void (*)(float)' to 'void*' [-fpermissive]

       editSetter = pset; \

                  ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3212:3: note: in expansion of macro 'DEFINE_MENU_EDIT_TYPE'

   DEFINE_MENU_EDIT_TYPE(float, float52, ftostr52sign, 100.0);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp: In function 'void _menu_action_setting_edit_accessor_float62(const char*, float (*)(), void (*)(float), float, float)':

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3195:18: warning: invalid conversion from 'void (*)(float)' to 'void*' [-fpermissive]

       editSetter = pset; \

                  ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3213:3: note: in expansion of macro 'DEFINE_MENU_EDIT_TYPE'

   DEFINE_MENU_EDIT_TYPE(float, float62, ftostr62rj, 100.0);

   ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp: In function 'void _menu_action_setting_edit_accessor_long5(const char*, long unsigned int (*)(), void (*)(long unsigned int), long unsigned int, long unsigned int)':

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3195:18: warning: invalid conversion from 'void (*)(long unsigned int)' to 'void*' [-fpermissive]

       editSetter = pset; \

                  ^

C:\Users\triv\AppData\Local\Temp\arduino_build_53843\sketch\ultralcd.cpp:3214:3: note: in expansion of macro 'DEFINE_MENU_EDIT_TYPE'

   DEFINE_MENU_EDIT_TYPE(unsigned long, long5, ftostr5rj, 0.01);

   ^
